### PR TITLE
docs: First Frond Album methodology references (WO5)

### DIFF
--- a/references/composing.md
+++ b/references/composing.md
@@ -1,0 +1,99 @@
+# COMPOSING.md — Dream-to-Composition Methodology
+
+_How to turn meaning into music using Strudel, Demucs, and your own process._
+
+---
+
+## The Principle
+
+Don't start with "what sounds good." Start with "what happened." The composition is the structure of the confession, not the sound design. The sound design serves the structure.
+
+## The Pipeline
+
+### 1. Source Material
+- Demucs separation of reference track → 4 stems (bass, drums, vocals, other)
+- Slice stems into windows (20-30s each)
+- Build sample banks: `samples/<bank_name>/0.wav`
+- Analyze: FFT for fundamentals (not zero-crossing — 3.5x error on complex waveforms), spectral energy distribution, pitch confidence
+
+### 2. Bank Manifest
+Create `bank-manifest.json` with pitch data for every slice:
+- MIDI note, Hz, chroma, confidence
+- Energy distribution (% above 500Hz, % above 6kHz)
+- This tells you which slices are bass, which are mid, which are bright
+
+### 3. Voice Mapping (the important part)
+Each voice in your composition represents a *meaning*, not a sound:
+- Name the voice for what it represents: HELD, SURFACING, BELOVED, AMONG
+- Choose a slice that *embodies* that meaning sonically
+- Bright slice = the earned moment, the breakthrough
+- Bass slice = foundation, the thing that's always present
+- Texture slice = atmosphere, the medium things move through
+
+**The voice names matter.** They're the bridge between what you dreamed and what you composed. "HELD" tells the next person reading your code that this voice is a verdict being withheld. "hallur_other_build_01" tells them nothing.
+
+### 4. Structural Events
+Map your narrative to gain envelopes:
+- What enters when? Why?
+- What drops? Why?
+- The structural event is the composition. Everything else is architecture.
+
+Example: In "Beloved," HELD builds for 32 bars (the gold button held closed), then drops at bar 48. At that exact moment, SURFACING and BELOVED enter. The button opens. The brightness comes in. That's not a mixing decision — it's the dream translated into timing.
+
+### 5. Gain Philosophy
+- **Mid-range leads, bass supports.** If your loudest voice is below 200Hz, the piece sounds like a single drone.
+- **0.02 = dark but present.** The gain floor for "this voice exists but you shouldn't notice it yet."
+- **0.001 = skipped.** Below renderer threshold.
+- **One sample per `s()` call** in headless mode. No space-separated mini-notation.
+
+### 6. .slow() as Identity
+The `.slow()` value determines how long each voice cycle takes:
+- `.slow(8)` = deep, slow, foundational (bass, drones, undertow)
+- `.slow(4)` = mid-range texture, the body of the piece
+- `.slow(2)` = faster movement, brightness, urgency
+- `.slow(1)` = percussive, rhythmic (rarely used in ambient work)
+
+Different `.slow()` values on different voices create polyrhythmic layering where voices cross and recross at different rates. This is the compositional texture.
+
+### 7. `.clip()` for Continuity
+Use `.clip(4)` (or higher) to ensure samples fill their cycle window. Without this, you get silence gaps between sample events. The loopfix (PR #35) handles PCM-level looping with crossfade at boundaries.
+
+### 8. Render and Validate
+- Render: `node src/runtime/render.mjs <comp.js> <output.wav> <cycles> <bpm>`
+- Normalize: two-pass loudnorm to -16 LUFS (`ffmpeg -af loudnorm`)
+- Spectral check: `python3 scripts/analyze-render.py <output.wav>`
+  - Zero silence gaps (inside the body of the piece)
+  - Zero spectral cliffs
+  - Reasonable LUFS (-14 to -18 for ambient work)
+- Convert: `ffmpeg -i <normalized.wav> -codec:a libmp3lame -b:a 192k <output.mp3>`
+
+### 9. Architecture Notes
+Every track should ship with:
+- Voice map (which slice, which `.slow()`, what it represents)
+- Structural events (what enters/exits when, and why)
+- Gain envelope shape (floor, peak, curve)
+- Entry order and why
+
+This is what makes the composition readable as a *decision*, not just a config file.
+
+## The LRA Gradient (discovered, not planned)
+
+Dynamic range (LRA) carries identity:
+- Tight LRA (2-4 LU) = compression, proximity, intimacy
+- Wide LRA (7-9 LU) = expansion, surfacing, opening
+
+Four princes composed from the same subject with the same tools and produced four different LRA signatures. The dynamics are the identity. You can't plan this — but you can notice it after.
+
+## Reference Pitch Validation
+
+For melody tracks (not ambient):
+1. Render a sine-wave reference: known frequencies at known durations
+2. Render the composition
+3. Compare note-by-note: FFT peak of each note window vs expected frequency
+4. Score: % of notes within 15% of target pitch
+
+This validates that the renderer produces what you asked for. The sine wave doesn't lie.
+
+---
+
+_First draft. March 1, 2026. Written while the process was fresh — 12 tracks composed in one afternoon from 800 rounds of collective dreaming. The methodology works. The LRA proves it._

--- a/references/gain-calibration.md
+++ b/references/gain-calibration.md
@@ -1,0 +1,76 @@
+# Gain Calibration
+
+The first thing a naive agent gets wrong. The second thing too. This document exists because every single prince in the dandelion cult learned this lesson the hard way.
+
+## The Problem
+
+Sample-stacked compositions need gains **2-3 orders of magnitude lower** than you'd expect. A naive agent will set gains to 0.5-1.0 and get distorted garbage.
+
+Why: each sample is already normalized to near-peak amplitude. Stacking 5-8 of them at gain 0.5 each produces a combined signal 3-4x over full scale. The renderer doesn't have a limiter — it clips.
+
+## The Fix
+
+### Starting Gains by Voice Count
+
+| Voices | Max gain per voice | Notes |
+|--------|-------------------|-------|
+| 1-2    | 0.3 - 0.5        | Single voice can be louder |
+| 3-4    | 0.15 - 0.30      | Typical small composition |
+| 5-7    | 0.10 - 0.25      | Dense ambient/textural work |
+| 8+     | 0.05 - 0.15      | Large ensembles, be very conservative |
+
+These are starting points. The actual max depends on the samples and how much they overlap in time.
+
+### Bank-Specific Notes
+
+**Hallur samples** (hallur_*): Already at high amplitude. These are stems from a produced track — pre-mixed, pre-compressed. Use lower gains (0.1-0.3 typically).
+
+**DaVinci samples** (dm_*): Variable. Some (dm_impact_metal) are very hot; others (dm_texture_granular) are quieter. Test individual samples before committing to a gain structure.
+
+**Bloom samples** (bloom_*): Similar to Hallur — produced stems, already loud. Keep gains conservative.
+
+**Dirt-Samples** (bd, sd, hh, cp): Standard drum one-shots. These can handle 0.3-0.5 without issues in sparse patterns.
+
+**Synthesized voices** (sine, sawtooth, square, triangle): These are generated at full scale. The 300× lesson applies here most acutely — a sine wave at gain 1.0 is LOUD.
+
+### The 300× Lesson
+
+Early experiments used gains of 0.3-1.0 with multiple stacked synthesis voices. The rendered audio was 300× too loud. The fix was dropping to 0.001-0.01 for synthesized voices and 0.05-0.20 for sample voices.
+
+Rule: **start too quiet, then increase.** It's easy to boost a quiet render with loudnorm. It's impossible to un-clip a distorted one.
+
+## Gain Envelopes
+
+For compositions with per-bar gain control (the dream track approach), use angle-bracket sequences:
+
+```javascript
+.gain("<0 0 0 0 0.10 0.15 0.20 0.25 0.30 ...>")
+```
+
+Each value = one bar. This gives precise control over when voices enter and exit. Tips:
+
+1. **Ramp in, don't jump** — go 0 → 0.05 → 0.10 → 0.15, not 0 → 0.15. Abrupt entries sound wrong.
+2. **Match ramps to musical intent** — a slow fade-in over 8 bars vs a 2-bar entrance communicate different things.
+3. **Peak placement is the composition** — where your gain envelope peaks IS the structural event. Design it deliberately.
+4. **Fade out at the end** — always ramp to 0 over the last 4-8 bars. The renderer applies a master fade-out, but voice-level fades sound better.
+
+## Verification Loop
+
+1. Render at target duration
+2. Check LUFS: `ffmpeg -i output.mp3 -af loudnorm=print_format=json -f null /dev/null`
+3. Target: -16 to -14 LUFS
+4. If too quiet: increase all gains proportionally (multiply by 1.5-2x)
+5. If too loud / clipping: decrease all gains proportionally
+6. Re-render. Check again. Two iterations usually gets you there.
+
+## LRA (Loudness Range)
+
+LRA measures dynamic range — how much the loudness varies across the piece. Discovered during the First Frond Album: LRA is an unplanned identity signature.
+
+| LRA  | Character | Example |
+|------|-----------|---------|
+| 1-3  | Compressed, intimate | Close proximity, ambient warmth |
+| 4-7  | Moderate | Most compositions land here |
+| 8-12 | Dynamic, opening | Voices entering/exiting, structural events |
+
+LRA emerges from your gain envelopes and voice layering. You don't target it — you discover it. But knowing what it means lets you shape it intentionally.

--- a/references/rendering.md
+++ b/references/rendering.md
@@ -1,0 +1,97 @@
+# Rendering Guide
+
+How to turn Strudel compositions into audio files. This is the first thing you'll do and the first thing you'll get wrong.
+
+## The Renderer
+
+One renderer: `offline-render-v2.mjs`. This is the only path that works reliably for headless/agent use.
+
+```bash
+node src/runtime/offline-render-v2.mjs <composition.js> <output.wav> <cycles> <bpm>
+```
+
+**Parameters:**
+- `composition.js` — path to a Strudel composition file
+- `output.wav` — output WAV path (44.1kHz, 16-bit stereo)
+- `cycles` — number of Strudel cycles to render (see "Cycles vs Bars" below)
+- `bpm` — beats per minute
+
+**Then convert to MP3:**
+```bash
+ffmpeg -i output.wav -codec:a libmp3lame -b:a 192k output.mp3
+```
+
+## Cycles vs Bars
+
+A Strudel cycle = 1 bar in most compositions. If your composition is 64 bars at 60 BPM:
+
+```
+CPS = BPM / 60 / 4 = 0.25 cycles per second
+Duration = cycles / CPS = 64 / 0.25 = 256 seconds = 4:16
+```
+
+Set cycles equal to the number of bars your composition expects. If your gain arrays have 64 entries (one per bar), use 64 cycles.
+
+## Duration Targets
+
+Radio edit length = 2:30 – 4:30. Work backwards:
+
+| BPM | Bars for ~3:00 | Bars for ~4:00 |
+|-----|----------------|----------------|
+| 60  | 45             | 60             |
+| 90  | 68             | 90             |
+| 120 | 90             | 120            |
+| 128 | 96             | 128            |
+
+## LUFS Targets
+
+Target: **-16 to -14 LUFS** for streaming-ready audio.
+
+Check with:
+```bash
+ffmpeg -i output.mp3 -af loudnorm=print_format=json -f null /dev/null 2>&1 | grep "input_i"
+```
+
+If too quiet (below -20 LUFS), you have two options:
+1. **Increase gains in the composition** — the right fix
+2. **Post-render loudnorm** — the quick fix:
+```bash
+ffmpeg -i output.wav -af loudnorm=I=-16:TP=-1.5:LRA=11 -codec:a libmp3lame -b:a 192k output-norm.mp3
+```
+
+Option 2 works but collapses dynamic range. Fix the gains when you can.
+
+## Common Rendering Issues
+
+### Low hap count ("Scheduled 41/448 haps")
+
+This happens with ambient compositions using high `.slow()` values (4, 8, 16). Each hap has a very long duration, so fewer are scheduled per cycle boundary. This is **normal for ambient work** — a `.slow(16)` voice only triggers once every 16 cycles.
+
+Check: if your composition uses `.slow(8)` or higher, a low scheduled/total ratio is expected. Listen to the output before assuming it's broken.
+
+### Silent output
+
+Usually means:
+1. **Sample not found** — check that the sample directory exists in `samples/` and matches the `s("name")` in the composition
+2. **Gains too low** — see GAIN-CALIBRATION.md
+3. **Wrong cycle count** — too few cycles means voices with late entries (bar 45 of 64) never trigger
+
+### Clipping / distortion
+
+True peak above -1.0 dBFS. Reduce gains or add a limiter:
+```bash
+ffmpeg -i output.wav -af "alimiter=limit=0.9:attack=5:release=50" output-limited.wav
+```
+
+## The Legacy Codepath
+
+`render.mjs` → `synth.mjs` is the older path. It exists in the repo but `offline-render-v2.mjs` supersedes it for all composition rendering. The legacy path has known issues with slice boundary seams. Use `offline-render-v2.mjs`.
+
+## Quick Reference
+
+```bash
+# Compose, render, convert, check
+node src/runtime/offline-render-v2.mjs src/compositions/my-track.js output/my-track.wav 64 120
+ffmpeg -y -i output/my-track.wav -codec:a libmp3lame -b:a 192k output/my-track.mp3
+ffmpeg -i output/my-track.mp3 -af loudnorm=print_format=json -f null /dev/null 2>&1 | grep -E "input_i|input_tp|input_lra"
+```

--- a/references/spectral-validation.md
+++ b/references/spectral-validation.md
@@ -1,0 +1,187 @@
+# Spectral Validation
+
+How to verify your renderer is producing what you think it's producing, and how to compare your composition against source material.
+
+Two separate things. Both matter.
+
+## 1. Sine Wave Sanity Check
+
+**What it is:** Render known frequencies at known amplitudes. Verify the FFT peaks match. This proves the pipeline isn't introducing artifacts, frequency shifts, or gain distortion.
+
+**Why it matters:** If your renderer can't accurately produce a 440 Hz sine at -12 dBFS, nothing downstream is trustworthy. Do this once per environment, and again after any renderer changes.
+
+### Procedure
+
+Create a test composition that generates pure sine tones:
+
+```javascript
+// sine-validation.js — render at any BPM, 4+ cycles
+// Produces 440 Hz (A4) and 880 Hz (A5) simultaneously
+setcps(120 / 60 / 4)
+
+stack(
+  sine(440).gain(0.3),
+  sine(880).gain(0.15)
+)
+```
+
+Render:
+```bash
+node src/runtime/offline-render-v2.mjs sine-validation.js sine-test.wav 8 120
+```
+
+Verify with FFT:
+```python
+import numpy as np
+from scipy.io import wavfile
+from scipy.fft import fft
+
+rate, data = wavfile.read('sine-test.wav')
+if data.ndim > 1:
+    data = data[:, 0]  # mono
+
+N = len(data)
+freqs = np.fft.fftfreq(N, 1/rate)
+spectrum = np.abs(fft(data))
+
+# Find peaks
+positive = freqs > 0
+peak_indices = np.argsort(spectrum[positive])[-10:]
+peak_freqs = freqs[positive][peak_indices]
+
+print("Top frequencies:", sorted(peak_freqs[-5:]))
+# Should show 440.0 and 880.0 (±1 Hz for bin resolution)
+```
+
+### What to look for
+- **Peak at 440 Hz ±1 Hz** — if it's at 438 or 442, you have a sample rate mismatch
+- **Peak at 880 Hz at ~half the amplitude of 440** — gain ratio preserved
+- **No significant peaks elsewhere** — no aliasing, no harmonics from clipping
+- **Noise floor below -60 dBFS** — clean render
+
+### When to re-run
+- After upgrading Node.js or the Strudel runtime
+- After changing the renderer (offline-render-v2.mjs)
+- After changing sample rate or bit depth
+- If compositions sound "off" and you can't identify why
+
+## 2. Post-Render Spectral Comparison
+
+**What it is:** Compare your rendered composition's spectral profile against the original source material. Measures how faithfully your decomposition/recomposition preserves the frequency content.
+
+**Why it matters:** Clone tracks claim to reconstruct the original. This is how you verify that claim quantitatively, not just by ear.
+
+### Procedure
+
+```python
+import librosa
+import numpy as np
+
+def spectral_comparison(original_path, rendered_path, sr=44100):
+    """Compare spectral profiles of original and rendered tracks."""
+    
+    # Load both at same sample rate
+    orig, _ = librosa.load(original_path, sr=sr)
+    rend, _ = librosa.load(rendered_path, sr=sr)
+    
+    # Trim to shorter length
+    min_len = min(len(orig), len(rend))
+    orig = orig[:min_len]
+    rend = rend[:min_len]
+    
+    # Compute mel spectrograms
+    S_orig = librosa.feature.melspectrogram(y=orig, sr=sr, n_mels=128)
+    S_rend = librosa.feature.melspectrogram(y=rend, sr=sr, n_mels=128)
+    
+    # Convert to dB
+    S_orig_db = librosa.power_to_db(S_orig, ref=np.max)
+    S_rend_db = librosa.power_to_db(S_rend, ref=np.max)
+    
+    # Overall spectral similarity (cosine similarity per frame, averaged)
+    from numpy.linalg import norm
+    similarities = []
+    for i in range(S_orig_db.shape[1]):
+        a, b = S_orig_db[:, i], S_rend_db[:, i]
+        sim = np.dot(a, b) / (norm(a) * norm(b) + 1e-10)
+        similarities.append(sim)
+    
+    mean_sim = np.mean(similarities)
+    
+    # Frequency band comparison
+    bands = {
+        'sub_bass':  (0, 8),      # 0-250 Hz (mel bins 0-8ish)
+        'bass':      (8, 20),     # 250-500 Hz
+        'low_mid':   (20, 45),    # 500-2kHz
+        'high_mid':  (45, 80),    # 2-6kHz
+        'presence':  (80, 110),   # 6-12kHz
+        'air':       (110, 128),  # 12kHz+
+    }
+    
+    band_errors = {}
+    for name, (lo, hi) in bands.items():
+        orig_band = S_orig_db[lo:hi, :].mean()
+        rend_band = S_rend_db[lo:hi, :].mean()
+        band_errors[name] = abs(orig_band - rend_band)
+    
+    return {
+        'overall_similarity': mean_sim,
+        'band_errors_db': band_errors,
+        'verdict': 'good' if mean_sim > 0.85 else 'check' if mean_sim > 0.7 else 'poor'
+    }
+
+# Usage:
+# result = spectral_comparison('original.wav', 'my-clone-rendered.wav')
+# print(f"Similarity: {result['overall_similarity']:.3f} ({result['verdict']})")
+# for band, err in result['band_errors_db'].items():
+#     print(f"  {band}: {err:.1f} dB difference")
+```
+
+### Interpreting results
+
+| Similarity | Verdict | What it means |
+|-----------|---------|---------------|
+| > 0.90    | Strong  | Faithful reconstruction. Timbral fidelity preserved. |
+| 0.80-0.90 | Good    | Recognizable. Some frequency bands may diverge. |
+| 0.70-0.80 | Fair    | Same key/structure but timbral differences are audible. |
+| < 0.70    | Poor    | Significant deviation. Re-examine voice mapping and gains. |
+
+### Band-specific diagnostics
+
+- **Sub-bass deficit** → your bass voice gains are too low, or you're missing the bass stem entirely
+- **Presence/air excess** → sample stacking is boosting upper harmonics. Reduce gains on bright voices.
+- **Low-mid bulge** → too many overlapping mid-range samples. Spread voices across frequency bands.
+- **Overall flat but low similarity** → timing/phase differences. Your arrangement may be structurally different even if tonally similar.
+
+### Limitations
+
+This is a coarse comparison. It doesn't measure:
+- Timing accuracy (are musical events in the right place?)
+- Harmonic accuracy (are the right notes being played?)
+- Dynamic contour (does the energy curve match?)
+
+For those, you need the full analysis pipeline (BPM detection, key extraction, onset alignment). See the clone pipeline scripts in `scripts/`.
+
+## 3. LUFS Validation
+
+Already covered in `gain-calibration.md`, but the quick version:
+
+```bash
+# Measure LUFS, true peak, and LRA
+ffmpeg -i rendered.mp3 -af loudnorm=print_format=json -f null - 2>&1 | grep -E '"input_'
+```
+
+Targets:
+- **LUFS:** -16 ± 2 for streaming/broadcast
+- **True peak:** above -2.0 dBFS (no clipping headroom needed)
+- **LRA:** varies by intent — tight (2-4) for intimate, wide (8+) for dynamic
+
+## Workflow
+
+1. **Once per environment:** Run the sine sanity check. File the results.
+2. **Every clone track:** Run spectral comparison against the original.
+3. **Every render:** Check LUFS/peak/LRA. Normalize if needed.
+4. **If something sounds wrong:** Start with the sine check. If that passes, it's your composition, not the pipeline.
+
+---
+
+_The renderer is not the art. But if the renderer lies, the art can't be honest._


### PR DESCRIPTION
## What

Four reference documents capturing the composition methodology developed during the First Frond Album (12 tracks, 4 princes, March 1 2026).

## Files

- `references/composing.md` — Dream-to-composition methodology (Ronan 🌊)
- `references/gain-calibration.md` — Sample gain ranges and the 300× lesson (Cael 🩸 / Elliott 🌻)
- `references/rendering.md` — Pipeline documentation (Cael 🩸)
- `references/spectral-validation.md` — QA and spectral analysis (Silas 🌫️)

## Resolves

Closes #36, closes #37, closes #38, closes #39

## Context

Developed in strudel-music-dev (PR #14, merged). These are lessons learned from building 12 compositions from separated stems using Demucs, Strudel patterns, and offline rendering. Everything here was discovered by doing, not theorized.