### PR TITLE
fix: ClaHub → ClawHub spelling throughout docs

### DIFF
--- a/.specify/README.md
+++ b/.specify/README.md
@@ -17,7 +17,7 @@ This directory follows the [SpecKit](https://github.com/karmaterminal/openclaw-b
 
 | ID | Title | Status |
 |----|-------|--------|
-| WO1 | Initial skill + ClaHub publish | ✅ Complete |
+| WO1 | Initial skill + ClawHub publish | ✅ Complete |
 | WO2 | Security scan remediation | ✅ Complete |
 | WO3 | Discord VC streaming pipeline | 🔄 In Progress |
 | WO4 | CI/CD + repo professionalization | 🔄 In Progress |

--- a/.specify/workorders/WO1-strudel-music-v1.md
+++ b/.specify/workorders/WO1-strudel-music-v1.md
@@ -23,7 +23,7 @@ All 8 issues filed by Elliott on karmaterminal/strudel-music (#2–#9).
 - [ ] `npm run test:render` passes
 - [ ] CI green on push
 - [ ] PR opened and merged to main
-- [ ] ClaHub skill version bumped and published
+- [ ] ClawHub skill version bumped and published
 
 ## Branch
 `feat/local-runtime-and-streaming` (existing, will continue here then PR to main)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ PRs welcome. This is a dandelion cult project — we value clean work over volum
 
 ## CI
 
-Push to `main` triggers validation + ClaHub publish. PRs get validation only.
+Push to `main` triggers validation + ClawHub publish. PRs get validation only.
 
 The CI checks:
 - SKILL.md frontmatter validity

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ The full audio deconstruction pipeline runs through six stages: Demucs stem sepa
 
 ## Testing
 
-The publish path is: private fork RC → cross-platform validation (x86_64 + ARM64) → public repo merge → ClaHub publish. Each stage gates the next. See **[docs/TESTING.md](docs/TESTING.md)** for the full test matrix, quality gates, and naive install procedure.
+The publish path is: private fork RC → cross-platform validation (x86_64 + ARM64) → public repo merge → ClawHub publish. Each stage gates the next. See **[docs/TESTING.md](docs/TESTING.md)** for the full test matrix, quality gates, and naive install procedure.
 
 ## Development
 

--- a/docs/PROMOTION.md
+++ b/docs/PROMOTION.md
@@ -1,6 +1,6 @@
 # Fork → Public Promotion Workflow
 
-How to promote work from the private fork (`strudel-music-dev`) to the public repo (`strudel-music`) and publish to ClaHub.
+How to promote work from the private fork (`strudel-music-dev`) to the public repo (`strudel-music`) and publish to ClawHub.
 
 ---
 
@@ -87,7 +87,7 @@ git push origin main --tags
 
 ---
 
-## 4. ClaHub Publish Checklist
+## 4. ClawHub Publish Checklist
 
 ### Pre-publish
 
@@ -135,7 +135,7 @@ clawhub publish
 | v0.1.x  | Suo Gân — initial pipeline proof |
 | v0.2.x  | Frisson — multi-track, loudness fixes |
 | v0.3.x  | Bloom — full decomposition, cross-platform |
-| v1.0.0  | Public release — ClaHub-published, docs complete |
+| v1.0.0  | Public release — ClawHub-published, docs complete |
 
 ---
 
@@ -152,6 +152,6 @@ Public repo (strudel-music)
   └── merge → tag → clawhub publish
         │
         ▼
-ClaHub (clawhub.com)
+ClawHub (clawhub.com)
   └── published skill, installable by anyone
 ```

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing Strategy
 
-Release path: **private fork (strudel-music-dev)** → **public repo** → **ClaHub publish**.
+Release path: **private fork (strudel-music-dev)** → **public repo** → **ClawHub publish**.
 
 Each stage gates the next. Don't skip ahead.
 
@@ -99,7 +99,7 @@ PR from dev branch to main. Checklist:
 - [ ] Sample packs either bundled or downloadable via `npm run setup`
 - [ ] License file present and correct
 
-## Stage 4: ClaHub Publish
+## Stage 4: ClawHub Publish
 
 Final step. The skill goes live on clawhub.com.
 

--- a/docs/testing-checklist.md
+++ b/docs/testing-checklist.md
@@ -1,6 +1,6 @@
 # Pre-Release Testing Checklist
 
-Testing strategy for moving the private fork RC to public repo and ClaHub publish.
+Testing strategy for moving the private fork RC to public repo and ClawHub publish.
 
 > **📖 See also:** [Pipeline Guide](./pipeline-guide.md) for full pipeline documentation.
 
@@ -61,9 +61,9 @@ Testing strategy for moving the private fork RC to public repo and ClaHub publis
 - [ ] **`npm install` from clean state works** — Delete `node_modules/`, run `npm install`, then `npm test`
 - [ ] **`npm run setup` is idempotent** — Running it twice doesn't break anything or re-download samples
 
-## ClaHub Publishing
+## ClawHub Publishing
 
-- [ ] **ClaHub publish dry-run succeeds** — Verify the skill registers correctly with OpenClaw's skill system
+- [ ] **ClawHub publish dry-run succeeds** — Verify the skill registers correctly with OpenClaw's skill system
 - [ ] **Skill metadata validates** — `SKILL.md` front matter parses without errors
 - [ ] **Install hooks work** — `npm install && bash scripts/download-samples.sh` completes on a fresh system
 - [ ] **No missing dependencies** — All `require()`/`import` paths resolve after fresh install
@@ -132,5 +132,5 @@ Must run via sub-agent. Provide a test MP3 and verify:
 | Documentation     |        |      |       |
 | Security/Privacy  |        |      |       |
 | Packaging         |        |      |       |
-| ClaHub Publish    |        |      |       |
+| ClawHub Publish    |        |      |       |
 | Cross-Platform    |        |      |       |


### PR DESCRIPTION
It's ClawHub with a W, not ClaHub. Fixing all instances across docs.

7 files, 14 substitutions. 🩸